### PR TITLE
Add Pathways age-based developmental guidance

### DIFF
--- a/resources/pathways/by-age/0-3-months/milestones.md
+++ b/resources/pathways/by-age/0-3-months/milestones.md
@@ -1,0 +1,16 @@
+# 0-3 Months: Developmental Milestones
+
+## High-Level Guidance
+- Encourage daily tummy time to build head and neck control.
+- Respond to cries and cues to build trust and security.
+- Provide simple visual and auditory stimulation.
+
+## Developmental Tips
+- Offer short, frequent tummy time sessions on a firm surface.
+- Talk, sing, and make facial expressions while your baby is awake.
+- Provide safe opportunities for kicking and arm movements.
+
+## Sources
+- [Pathways.org: 0-3 Months](https://pathways.org/baby-development/0-3-months/)
+
+*This overview is based on guidance from Pathways.org and is not a substitute for medical advice.*

--- a/resources/pathways/by-age/10-12-months/milestones.md
+++ b/resources/pathways/by-age/10-12-months/milestones.md
@@ -1,0 +1,16 @@
+# 10-12 Months: Developmental Milestones
+
+## High-Level Guidance
+- Support pulling to stand and cruising along furniture.
+- Encourage pincer grasp and self-feeding skills.
+- Promote early words and intentional gestures.
+
+## Developmental Tips
+- Place sturdy furniture for practice cruising and supported steps.
+- Offer small finger foods to practice grasping.
+- Use simple gestures like waving or clapping and label objects frequently.
+
+## Sources
+- [Pathways.org: 10-12 Months](https://pathways.org/baby-development/10-12-months/)
+
+*This overview is based on guidance from Pathways.org and is not a substitute for medical advice.*

--- a/resources/pathways/by-age/13-18-months/milestones.md
+++ b/resources/pathways/by-age/13-18-months/milestones.md
@@ -1,0 +1,16 @@
+# 13-18 Months: Developmental Milestones
+
+## High-Level Guidance
+- Encourage confident walking and climbing.
+- Support early problem-solving and imitation play.
+- Expand vocabulary through daily conversations.
+
+## Developmental Tips
+- Provide push toys and safe obstacles for practice.
+- Read picture books and name common objects.
+- Encourage copying your actions like brushing hair or stirring.
+
+## Sources
+- [Pathways.org: 13-18 Months](https://pathways.org/baby-development/13-18-months/)
+
+*This overview is based on guidance from Pathways.org and is not a substitute for medical advice.*

--- a/resources/pathways/by-age/19-24-months/milestones.md
+++ b/resources/pathways/by-age/19-24-months/milestones.md
@@ -1,0 +1,16 @@
+# 19-24 Months: Developmental Milestones
+
+## High-Level Guidance
+- Support running, climbing, and kicking skills.
+- Encourage pretend play and simple problem solving.
+- Foster two-word phrases and growing independence.
+
+## Developmental Tips
+- Offer opportunities for climbing, kicking balls, and push/pull toys.
+- Provide simple props for pretend play like dolls or toy kitchens.
+- Expand language by labeling actions and offering choices.
+
+## Sources
+- [Pathways.org: 19-24 Months](https://pathways.org/baby-development/19-24-months/)
+
+*This overview is based on guidance from Pathways.org and is not a substitute for medical advice.*

--- a/resources/pathways/by-age/4-6-months/milestones.md
+++ b/resources/pathways/by-age/4-6-months/milestones.md
@@ -1,0 +1,16 @@
+# 4-6 Months: Developmental Milestones
+
+## High-Level Guidance
+- Support rolling and beginning sitting skills.
+- Encourage reaching for and grasping toys.
+- Continue to nurture social interaction and vocal play.
+
+## Developmental Tips
+- Give plenty of floor time with toys placed just out of reach.
+- Assist with supported sitting using pillows or your lap.
+- Imitate your baby's sounds and engage in back-and-forth babbling.
+
+## Sources
+- [Pathways.org: 4-6 Months](https://pathways.org/baby-development/4-6-months/)
+
+*This overview is based on guidance from Pathways.org and is not a substitute for medical advice.*

--- a/resources/pathways/by-age/7-9-months/milestones.md
+++ b/resources/pathways/by-age/7-9-months/milestones.md
@@ -1,0 +1,16 @@
+# 7-9 Months: Developmental Milestones
+
+## High-Level Guidance
+- Encourage independent sitting and beginning crawling.
+- Promote hand-to-hand transfers and object exploration.
+- Foster responsive communication and name recognition.
+
+## Developmental Tips
+- Create safe floor spaces for scooting and crawling practice.
+- Play peekaboo and other games that build object permanence.
+- Respond to babbles and use your baby's name often.
+
+## Sources
+- [Pathways.org: 7-9 Months](https://pathways.org/baby-development/7-9-months/)
+
+*This overview is based on guidance from Pathways.org and is not a substitute for medical advice.*


### PR DESCRIPTION
## Summary
- Add Pathways.org resource directory organized by major age ranges
- Provide milestone guidance, tips, and source links for ages 0-24 months

## Testing
- `npm test` (fails: could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68979f9352e083299e105730935cdb21